### PR TITLE
Added the subject into the practise path

### DIFF
--- a/emas/transforms/shortcodehtml2html.py
+++ b/emas/transforms/shortcodehtml2html.py
@@ -53,9 +53,12 @@ class shortcodehtml_to_html:
         # we have no context to work with in the transform so we are
         # simply assuming that we are always in the context of cnxml
         # file
+        subject = parts.path.split('/')[-5]
         grade = parts.path.split('/')[-4]
         chapter = parts.path.split('/')[-3]
-        practice_url = "/@@practice/%s/%s" % (grade, chapter)
+        # After consolidating site, subject needs to be included in path
+        # for science practise links to work
+        practice_url = "/practice/%s/%s/%s" % (subject,grade, chapter)
 
         example_html = """
 <div class="answer-section">


### PR DESCRIPTION
After the combination of the Maths and Science this year (2015) there "Practise more questions like this" buttons were broken for science and worked by chance for maths.

The reason is that the path the button linked to didn't need to specify the subject in the past because the subject sites were separate but now we need to include the subject.

Currently Maths links do work because they default back to root but the science ones take you to a maths practise session which is completely wrong.

The fix seems to be to include the subject in the practise path.

I did this in the one place I think it needs to happen but I don't have a local plone install to test this on.

Please can you check that this logic works for maths and science and roll this out for us.

Mark
